### PR TITLE
Dulldusk master

### DIFF
--- a/ChromePhp.php
+++ b/ChromePhp.php
@@ -399,22 +399,32 @@ class ChromePhp
         $header = self::HEADER_NAME . ': ' . $this->_encode($data);
         // Most HTTPD servers have a default header line length limit of 8kb, must test to avoid 500 Internal Server Error.
         if (strlen($header) > self::HTTPD_HEADER_LIMIT) {
-            $data['rows'] = array();
-            $data['rows'][] = array(array('ChromePHP Error: The HTML header will surpass the limit of '.$this->_formatSize(self::HTTPD_HEADER_LIMIT).' ('.$this->_formatSize(strlen($header)).') - You can increase the HTTPD_HEADER_LIMIT on ChromePHP class, according to your Apache LimitRequestFieldsize directive'), '', self::ERROR);
+            $data['rows'] = [];
+            $data['rows'][] = [
+                [
+                    'ChromePHP Error: The HTML header will surpass the limit of ' .
+                    $this->_formatSize(self::HTTPD_HEADER_LIMIT) . ' (' . $this->_formatSize(strlen($header)) .
+                    ') - You can increase the HTTPD_HEADER_LIMIT on ChromePHP class, according to your Apache ' .
+                    'LimitRequestFieldsize directive'
+                ], '', self::ERROR
+            ];
             $header = self::HEADER_NAME . ': ' . $this->_encode($data);
         }
         header($header);
     }
 
     protected function _formatSize($arg) {
-        if ($arg>0){
+        if ($arg > 0) {
             $j = 0;
-            $ext = array("bytes","Kb","Mb","Gb","Tb");
-            while ($arg >= pow(1024,$j)) ++$j; {
-                $arg = (round($arg/pow(1024,$j-1)*100)/100).($ext[$j-1]);
+            $ext = ["bytes","Kb","Mb","Gb","Tb"];
+            while ($arg >= pow(1024, $j)) ++$j; {
+                $arg = (round($arg / pow(1024, $j - 1) * 100) / 100).($ext[$j - 1]);
             }
+
             return $arg;
-        } else return "0Kb";
+        }
+
+        return "0Kb";
     }
 
     /**


### PR DESCRIPTION
From ccampbell/chromephp#63:

> The HTTP spec does not define a limit, however many servers do by
> default:
> Apache 2.0, 2.2: 8K
> nginx: 4K - 8K
> IIS: varies by version, 8K - 16K
> Tomcat: varies by version, 8K - 48K(?!)
> 
> Ans it is not just with ChormePHP.
> Some user agents and some requests just get too big for web server
> defaults.
> It seems like a silly problem to run into, but it keeps happening.

Plus:
- Modern code formatting.